### PR TITLE
Fix teleport to buddha map

### DIFF
--- a/tuxemon/resources/maps/map1.tmx
+++ b/tuxemon/resources/maps/map1.tmx
@@ -219,10 +219,10 @@
     <property name="cond1" value="is player_at"/>
    </properties>
   </object>
-  <object id="82" name="Go to Buddha Mountain" type="event" x="378" y="248">
+  <object id="82" name="Go to Buddha Mountain" type="event" x="368" y="240" width="16" height="16">
    <properties>
     <property name="act1" value="transition_teleport BuddhaMountain.tmx,3,90,0.5"/>
-    <property name="cond1" value="is player_at 23,15"/>
+    <property name="cond1" value="is player_at"/>
    </properties>
   </object>
  </objectgroup>


### PR DESCRIPTION
If you enable "snap to grid" in Tiled, you can place events easier. For the "player_at" condition, the coordinates aren't needed and will instead use the event's location.
